### PR TITLE
Adding error handling when token is not supplied and database connection errors in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv/
 .DS_Store
 .idea/
 .pytest_cache/
+.env.bat

--- a/app/helpers/admin.py
+++ b/app/helpers/admin.py
@@ -11,4 +11,4 @@ def has_role(role_list, role_name) -> bool:
 
 def get_current_user(access_token) -> object:
     payload = jwt.decode(access_token , os.getenv("JWT_SALT") , algorithms= ['HS256'])
-    return payload['user_claims']
+    return payload['user_claims']['roles'][0]

--- a/app/helpers/database_service.py
+++ b/app/helpers/database_service.py
@@ -422,6 +422,7 @@ class PostgresqlDbService(DatabaseService):
             return False
 
     def check_db_connection(self):
+        super_connection = None
         try:
             super_connection = self.create_connection()
             if not super_connection:

--- a/app/helpers/decorators.py
+++ b/app/helpers/decorators.py
@@ -11,6 +11,9 @@ def authenticate(fn):
 
         payload : object = {}
 
+        if kwargs['access_token'] is None :
+            raise HTTPException(status_code=401 , detail="Access token was not supplied")
+
         try :
             payload = jwt.decode(kwargs['access_token'] , os.getenv("JWT_SALT") , algorithms= ['HS256'])
 

--- a/config.py
+++ b/config.py
@@ -14,8 +14,11 @@ class BaseConfig:
 
 
 class DevelopmentConfig(BaseConfig):
-    pass
+    ADMIN_PSQL_USER : str = os.getenv("ADMIN_PSQL_USER")
+    ADMIN_PSQL_PASSWORD : str = os.getenv("ADMIN_PSQL_PASSWORD")
 
+    ADMIN_MYSQL_USER : str = os.getenv("ADMIN_MYSQL_USER")
+    ADMIN_MYSQL_PASSWORD : str = os.getenv("ADMIN_MYSQL_PASSWORD")
 
 class ProductionConfig(BaseConfig):
     pass


### PR DESCRIPTION
This is meant to handle any errors that arise when an access token is not supplied . And also errors that arise when the `password` and `user` are not supplied to the database sevice to create a database. 