### PR TITLE
fix: make environment variables seen while running docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ services:
       PYTHONDONTWRITEBYTECODE: 1
       PYTHONUNBUFFERED: 1
       DATABASE_USER: postgres
+      ADMIN_MYSQL_USER: ${ADMIN_MYSQL_USER}
+      ADMIN_MYSQL_HOST: ${ADMIN_MYSQL_HOST}
+      ADMIN_MYSQL_PORT: ${ADMIN_MYSQL_PORT}
+      ADMIN_MYSQL_PASSWORD: ${ADMIN_MYSQL_PASSWORD}
+      ADMIN_PSQL_HOST: ${ADMIN_PSQL_HOST}
+      ADMIN_PSQL_USER: ${ADMIN_PSQL_USER}
+      ADMIN_PSQL_PASSWORD: ${ADMIN_PSQL_PASSWORD}
+      ADMIN_PSQL_PORT: ${ADMIN_PSQL_PORT}
       DATABASE_URI: ${DATABASE_URI:-postgresql://postgres:postgres@database_db:5432/cranecloud_db}
       TEST_DATABASE_URI: ${TEST_DATABASE_URI:-postgresql://postgres:postgres@database_db:5432/cranecloud_db_test}
     ports:


### PR DESCRIPTION
- Make environment variables seen while running docker compose